### PR TITLE
Add debug infrastructure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,8 +5,17 @@
 #include "modules/control.h"
 #include "modules/parameters.h"
 
+#define DEBUG
+#define DEBUG_MODULE "main"
+#include "util/debug.h"
+
 void mainSetup(void)
 {
+  DEBUG_BEGIN;
+  
+  // TODO: cleanup prints
+  DEBUG_PRINT("setup");
+
   // TODO: Handle failure conditions
   controlModuleInit();
   sensorsModuleInit();
@@ -16,6 +25,8 @@ void mainSetup(void)
 
 void mainLoop(void)
 {
+  // TODO: Clean up prints
+  DEBUG_PRINT_EVERY(10000, "in main loop");
   // Run all modules in RR; take specified actions in the event of failure
   
   if (controlModuleRun() != MODULE_OK) {

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -1,0 +1,47 @@
+
+#include <stdio.h>
+
+#include <HardwareSerial.h>
+
+#ifndef DEBUG_MODULE
+#error "Cannot include debug.h without defining DEBUG_MODULE"
+#endif
+
+#ifndef DEBUG_BUFFER_SIZE
+#define DEBUG_BUFFER_SIZE 128
+#endif
+
+#ifndef DEBUG_SERIAL_PORT
+#define DEBUG_SERIAL_PORT Serial
+#endif
+
+// Initial setup of debug; only to be used once
+#define DEBUG_BEGIN DEBUG_SERIAL_PORT.begin(115200)
+
+#ifdef DEBUG
+
+// Use DEBUG_PRINT to add print messages like printf
+#define DEBUG_PRINT(...)                              \
+  do {                                                \
+    char _buf[DEBUG_BUFFER_SIZE];                     \
+    snprintf(_buf, DEBUG_BUFFER_SIZE, __VA_ARGS__);   \
+    DEBUG_SERIAL_PORT.print("[" DEBUG_MODULE "] ");        \
+    DEBUG_SERIAL_PORT.println(_buf);                       \
+  } while (0);
+
+// Use DEBUG_PRINT_EVERY to add print messages line printf, but it will only
+// print the message every i times the line is reached (note: it costs 2 bytes
+// to remember this per line)
+#define DEBUG_PRINT_EVERY(i, ...)                     \
+  do {                                                \
+    static unsigned int _count = 0;                   \
+    if ((++_count) / i) {                             \
+      DEBUG_PRINT(__VA_ARGS__);                       \
+      _count = 0;                                     \
+    }                                                 \
+  } while (0);
+
+#else
+#define DEBUG_PRINT(...)
+#define DEBUG_PRINT_EVERY(...)
+#endif


### PR DESCRIPTION
Add standard debug infrastructure to the code via src/util/debug.h - use `DEBUG_PRINT` like you would `printf` in C. Note that you should only every include the header file directly from a source file and you need to define `DEBUG_MODULE` as a string representing the file in the log (see src/main.cpp for an example). You must also define `DEBUG` to enable the print messages.

To avoid spamming the log with print messages that happen very frequently, you can use `DEBUG_PRINT_EVERY` to print every n times the statement is reached.

Note, it uses the default programming interface serial connection