### PR TITLE
Create GitHub CI workflow for arduino code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,4 @@ jobs:
     
     # Compile the Arduino code and make sure it runs ok
     - name: Compile Arduino code
-      run: ./bin/arduino-cli compile --fqbn arduino:avr:mega:cpu=atmega2560 software-controller.ino
+      run: ./bin/arduino-cli compile --fqbn arduino:avr:mega:cpu=atmega2560 software-controller.ino -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+name: CI for Microcontroller
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but for the `master` and `develop` branch
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Install Arduino CLI for uploading Code data to Arduino MEGA
+    - name: Install Arduino CLI
+      run: curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+    
+    # Update Arduino Core information
+    - name: Update Arduino Core information
+      run: arduino-cli core update-index
+    
+    # Install tools for the Arduino MEGA board
+    - name: Install Arduino Board tools
+      run: arduino-cli core install arduino:avr:mega:cpu=atmega2560
+    
+    # Compile the Arduino code and make sure it runs ok
+    - name: Compile Arduino code
+      run: arduino-cli compile --fqbn arduino:samd:mkr1000 software-controller

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     
     # Install tools for the Arduino MEGA board
     - name: Install Arduino Board tools
-      run: ./bin/arduino-cli core install arduino:avr:mega:cpu=atmega2560
+      run: ./bin/arduino-cli core install arduino:avr:mega
     
     # Compile the Arduino code and make sure it runs ok
     - name: Compile Arduino code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,4 @@ jobs:
     
     # Compile the Arduino code and make sure it runs ok
     - name: Compile Arduino code
-      run: ./bin/arduino-cli compile --fqbn arduino:avr:mega:cpu=atmega2560 software-controller
+      run: ./bin/arduino-cli compile --fqbn arduino:avr:mega:cpu=atmega2560 software-controller.ino

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       
     # Add Arduino CLI Path
     - name: Add Arduino CLI to PATH
-      run: export PATH=$PATH:/home/runner/work/software-controller/software-controller/bin
+      run: export PATH=$PATH:/home/runner/work/software-controller/software-controller/bin && $PATH
     
     # Print Current Path
     - name: Print current path and contents

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,8 @@ jobs:
     
     # Install tools for the Arduino MEGA board
     - name: Install Arduino Board tools
-      run: ./bin/arduino-cli core install arduino:avr:mega
+      run: ./bin/arduino-cli core install arduino:avr
     
     # Compile the Arduino code and make sure it runs ok
     - name: Compile Arduino code
-      run: ./bin/arduino-cli compile --fqbn arduino:samd:mkr1000 software-controller
+      run: ./bin/arduino-cli compile --fqbn arduino:avr:mega:cpu=atmega2560 software-controller

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       
     # Add Arduino CLI Path
     - name: Add Arduino CLI to PATH
-      run: export PATH=$PATH:/home/runner/work/software-controller/software-controller/bin && $PATH
+      run: export PATH=$PATH:/home/runner/work/software-controller/software-controller/bin && echo $PATH
     
     # Print Current Path
     - name: Print current path and contents
@@ -38,12 +38,12 @@ jobs:
     
     # Update Arduino Core information
     - name: Update Arduino Core information
-      run: arduino-cli core update-index
+      run: ./bin/arduino-cli core update-index
     
     # Install tools for the Arduino MEGA board
     - name: Install Arduino Board tools
-      run: arduino-cli core install arduino:avr:mega:cpu=atmega2560
+      run: ./bin/arduino-cli core install arduino:avr:mega:cpu=atmega2560
     
     # Compile the Arduino code and make sure it runs ok
     - name: Compile Arduino code
-      run: arduino-cli compile --fqbn arduino:samd:mkr1000 software-controller
+      run: ./bin/arduino-cli compile --fqbn arduino:samd:mkr1000 software-controller

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,14 @@ jobs:
     - name: Add Arduino CLI to PATH
       run: export PATH=$PATH:/home/runner/work/software-controller/software-controller/bin
     
+    # Print Current Path
+    - name: Print current path and contents
+      run: pwd && ls
+    
+    # Print Contents of Arduino CLI installation path
+    - name: Print Arduino CLI install Path
+      run: ls /home/runner/work/software-controller/software-controller/bin
+    
     # Update Arduino Core information
     - name: Update Arduino Core information
       run: arduino-cli core update-index

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
     # Install Arduino CLI for uploading Code data to Arduino MEGA
     - name: Install Arduino CLI
       run: curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+      
+    # Add Arduino CLI Path
+    - name: Add Arduino CLI to PATH
+      run: export PATH=$PATH:/home/runner/work/software-controller/software-controller/bin
     
     # Update Arduino Core information
     - name: Update Arduino Core information


### PR DESCRIPTION
This code should attempt to download the `arduino-cli` onto an ubuntu 18.04 vm instance and compile the code to see if there are errors.

If this works properly, this CI can be used whenever a push or pull is made to the `master` or `develop` branches.