### PR TITLE
Fix hal/timer bugs

### DIFF
--- a/src/hal/timer.cpp
+++ b/src/hal/timer.cpp
@@ -1,8 +1,10 @@
 
-#include <Arduino.h>
+#include <stdint.h>
 
 #include "../hal/hal.h"
 #include "../hal/timer.h"
+
+#include <Arduino.h>
 
 int timerHalInit(void)
 {
@@ -10,10 +12,10 @@ int timerHalInit(void)
   return HAL_OK;
 }
 
-int timerHalBegin(struct timer* timer, unsigned int duration)
+int timerHalBegin(struct timer* timer, uint32_t duration)
 {
   if (timer) {
-    timer->start = (unsigned int) micros();
+    timer->start = (uint32_t) micros();
     timer->duration = duration;
     return HAL_OK;
   }
@@ -23,11 +25,16 @@ int timerHalBegin(struct timer* timer, unsigned int duration)
 int timerHalRun(struct timer* timer)
 {
   if (timer) {
-    if ((unsigned int) micros() - timer->start < timer->duration) {
+    if (((uint32_t) micros()) - timer->start < timer->duration) {
       return HAL_IN_PROGRESS;
     } else {
       return HAL_TIMEOUT;
     }
   }
   return HAL_FAIL;
+}
+
+uint32_t timerHalCurrent(struct timer* timer)
+{
+  return ((uint32_t) micros()) - timer->start;
 }

--- a/src/hal/timer.h
+++ b/src/hal/timer.h
@@ -2,25 +2,30 @@
 #ifndef __TIMER_HAL_H__
 #define __TIMER_HAL_H__
 
+#include <stdint.h>
+
 #include "../hal/hal.h"
 
 // Time units
-#define SEC   * 1
+#define SEC   * 1000000
 #define MSEC  * 1000
-#define USEC  * 1000000
+#define USEC  * 1
 
 struct timer {
-  unsigned int start;
-  unsigned int duration;
+  uint32_t start;
+  uint32_t duration;
 };
 
 // TODO: Doc
 int timerHalInit(void);
 
 // TODO: Doc
-int timerHalBegin(struct timer* timer, unsigned int duration);
+int timerHalBegin(struct timer* timer, uint32_t duration);
 
 // TODO: Doc
 int timerHalRun(struct timer* timer);
+
+// TODO: Doc
+uint32_t timerHalCurrent(struct timer* timer);
 
 #endif /* __TIMER_HAL_H__ */

--- a/src/hal/timer.h
+++ b/src/hal/timer.h
@@ -7,9 +7,9 @@
 #include "../hal/hal.h"
 
 // Time units
-#define SEC   * 1000000
-#define MSEC  * 1000
-#define USEC  * 1
+#define SEC   * 1000000UL
+#define MSEC  * 1000UL
+#define USEC  * 1UL
 
 struct timer {
   uint32_t start;


### PR DESCRIPTION
Type bugs in the timer hal were causing problems, especially after the move from Due (32-bit ARM) to MEGA (8-bit AVR) with respect to data types and sizes/types of literals.