### PR TITLE
Add Metrics (Timing) Infrastructure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #define DEBUG_MODULE "main"
 #include "util/debug.h"
 
+static struct metrics mainLoopMetrics;
 static struct metrics scheduleMetrics;
 static struct metrics controlModuleMetrics;
 static struct metrics sensorsModuleMetrics;
@@ -30,6 +31,7 @@ void mainSetup(void)
   parametersModuleInit();
   linkModuleInit();
 
+  metricsReset(&mainLoopMetrics);
   metricsReset(&scheduleMetrics);
   metricsReset(&controlModuleMetrics);
   metricsReset(&sensorsModuleMetrics);
@@ -40,6 +42,7 @@ void mainSetup(void)
 
 void mainLoop(void)
 {
+  metricsStart(&mainLoopMetrics);
   metricsStart(&scheduleMetrics);
   
   // Run all modules in RR; take specified actions in the event of failure
@@ -72,6 +75,10 @@ void mainLoop(void)
   metricsStop(&scheduleMetrics);
   DEBUG_PRINT_EVERY(25000, "Runtime Metrics:");
   DEBUG_PRINT_EVERY(25000, " Main loop:  %10lu us : %10lu us : %10lu us",
+                    mainLoopMetrics.minimum,
+                    mainLoopMetrics.average,
+                    mainLoopMetrics.maximum);
+  DEBUG_PRINT_EVERY(25000, " Scheduler:  %10lu us : %10lu us : %10lu us",
                     scheduleMetrics.minimum,
                     scheduleMetrics.average,
                     scheduleMetrics.maximum);
@@ -91,4 +98,5 @@ void mainLoop(void)
                     linkModuleMetrics.minimum,
                     linkModuleMetrics.average,
                     linkModuleMetrics.maximum);
+  metricsStop(&mainLoopMetrics);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,9 +5,17 @@
 #include "modules/control.h"
 #include "modules/parameters.h"
 
+#include "util/metrics.h"
+
 #define DEBUG
 #define DEBUG_MODULE "main"
 #include "util/debug.h"
+
+static struct metrics scheduleMetrics;
+static struct metrics controlModuleMetrics;
+static struct metrics sensorsModuleMetrics;
+static struct metrics parametersModuleMetrics;
+static struct metrics linkModuleMetrics;
 
 void mainSetup(void)
 {
@@ -21,29 +29,66 @@ void mainSetup(void)
   sensorsModuleInit();
   parametersModuleInit();
   linkModuleInit();
+
+  metricsReset(&scheduleMetrics);
+  metricsReset(&controlModuleMetrics);
+  metricsReset(&sensorsModuleMetrics);
+  metricsReset(&parametersModuleMetrics);
+  metricsReset(&linkModuleMetrics);
+  DEBUG_PRINT("setup done");
 }
 
 void mainLoop(void)
 {
-  // TODO: Clean up prints
-  DEBUG_PRINT_EVERY(50000, "in main loop");
-  // Run all modules in RR; take specified actions in the event of failure
+  metricsStart(&scheduleMetrics);
   
+  // Run all modules in RR; take specified actions in the event of failure
+  metricsStart(&controlModuleMetrics);
   if (controlModuleRun() != MODULE_OK) {
     // TODO: control module exited, trigger severe error
   }
+  metricsStop(&controlModuleMetrics);
   
+  metricsStart(&sensorsModuleMetrics);
   if (sensorsModuleRun() != MODULE_OK) {
     // TODO: sensor module exited, trigger severe error  
   }
+  metricsStop(&sensorsModuleMetrics);
 
+  metricsStart(&parametersModuleMetrics);
   if (parametersModuleRun() != MODULE_OK) {
     // TODO: parameters module exited, attempt recovery
   }
+  metricsStop(&parametersModuleMetrics);
 
+  metricsStart(&linkModuleMetrics);
   if (linkModuleRun() != MODULE_OK) {
     // TODO: link module exited, attempt recovery
   }
+  metricsStop(&linkModuleMetrics);
 
   // TODO: Failure actions (alarm, watchdog)
+
+  metricsStop(&scheduleMetrics);
+  DEBUG_PRINT_EVERY(25000, "Runtime Metrics:");
+  DEBUG_PRINT_EVERY(25000, " Main loop:  %10lu us : %10lu us : %10lu us",
+                    scheduleMetrics.minimum,
+                    scheduleMetrics.average,
+                    scheduleMetrics.maximum);
+  DEBUG_PRINT_EVERY(25000, " Control:    %10lu us : %10lu us : %10lu us",
+                    controlModuleMetrics.minimum,
+                    controlModuleMetrics.average,
+                    controlModuleMetrics.maximum);
+  DEBUG_PRINT_EVERY(25000, " Sensors:    %10lu us : %10lu us : %10lu us",
+                    sensorsModuleMetrics.minimum,
+                    sensorsModuleMetrics.average,
+                    sensorsModuleMetrics.maximum);
+  DEBUG_PRINT_EVERY(25000, " Parameters: %10lu us : %10lu us : %10lu us",
+                    parametersModuleMetrics.minimum,
+                    parametersModuleMetrics.average,
+                    parametersModuleMetrics.maximum);
+  DEBUG_PRINT_EVERY(25000, " Link:       %10lu us : %10lu us : %10lu us",
+                    linkModuleMetrics.minimum,
+                    linkModuleMetrics.average,
+                    linkModuleMetrics.maximum);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,12 +11,16 @@
 #define DEBUG_MODULE "main"
 #include "util/debug.h"
 
+#define MAIN_METRICS
+
+#ifdef MAIN_METRICS
 static struct metrics mainLoopMetrics;
 static struct metrics scheduleMetrics;
 static struct metrics controlModuleMetrics;
 static struct metrics sensorsModuleMetrics;
 static struct metrics parametersModuleMetrics;
 static struct metrics linkModuleMetrics;
+#endif
 
 void mainSetup(void)
 {
@@ -31,47 +35,68 @@ void mainSetup(void)
   parametersModuleInit();
   linkModuleInit();
 
+#ifdef MAIN_METRICS
   metricsReset(&mainLoopMetrics);
   metricsReset(&scheduleMetrics);
   metricsReset(&controlModuleMetrics);
   metricsReset(&sensorsModuleMetrics);
   metricsReset(&parametersModuleMetrics);
   metricsReset(&linkModuleMetrics);
+#endif
   DEBUG_PRINT("setup done");
 }
 
 void mainLoop(void)
 {
+#ifdef MAIN_METRICS
   metricsStart(&mainLoopMetrics);
   metricsStart(&scheduleMetrics);
-  
+#endif
+
   // Run all modules in RR; take specified actions in the event of failure
+#ifdef MAIN_METRICS
   metricsStart(&controlModuleMetrics);
+#endif
   if (controlModuleRun() != MODULE_OK) {
     // TODO: control module exited, trigger severe error
   }
+#ifdef MAIN_METRICS
   metricsStop(&controlModuleMetrics);
+#endif
   
+#ifdef MAIN_METRICS
   metricsStart(&sensorsModuleMetrics);
+#endif
   if (sensorsModuleRun() != MODULE_OK) {
     // TODO: sensor module exited, trigger severe error  
   }
+#ifdef MAIN_METRICS
   metricsStop(&sensorsModuleMetrics);
+#endif
 
+#ifdef MAIN_METRICS
   metricsStart(&parametersModuleMetrics);
+#endif
   if (parametersModuleRun() != MODULE_OK) {
     // TODO: parameters module exited, attempt recovery
   }
+#ifdef MAIN_METRICS
   metricsStop(&parametersModuleMetrics);
+#endif
 
+#ifdef MAIN_METRICS
   metricsStart(&linkModuleMetrics);
+#endif
   if (linkModuleRun() != MODULE_OK) {
     // TODO: link module exited, attempt recovery
   }
+#ifdef MAIN_METRICS
   metricsStop(&linkModuleMetrics);
+#endif
 
   // TODO: Failure actions (alarm, watchdog)
 
+#ifdef MAIN_METRICS
   metricsStop(&scheduleMetrics);
   DEBUG_PRINT_EVERY(25000, "Runtime Metrics:");
   DEBUG_PRINT_EVERY(25000, " Main loop:  %10lu us : %10lu us : %10lu us",
@@ -99,4 +124,5 @@ void mainLoop(void)
                     linkModuleMetrics.average,
                     linkModuleMetrics.maximum);
   metricsStop(&mainLoopMetrics);
+#endif
 }

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -16,29 +16,29 @@
 #endif
 
 // Initial setup of debug; only to be used once
-#define DEBUG_BEGIN DEBUG_SERIAL_PORT.begin(115200)
+#define DEBUG_BEGIN DEBUG_SERIAL_PORT.begin(230400)
 
 #ifdef DEBUG
 
 // Use DEBUG_PRINT to add print messages like printf
-#define DEBUG_PRINT(...)                              \
-  do {                                                \
-    char _buf[DEBUG_BUFFER_SIZE];                     \
-    snprintf(_buf, DEBUG_BUFFER_SIZE, __VA_ARGS__);   \
-    DEBUG_SERIAL_PORT.print("[" DEBUG_MODULE "] ");        \
-    DEBUG_SERIAL_PORT.println(_buf);                       \
+#define DEBUG_PRINT(...)                                                \
+  do {                                                                  \
+    char _buf[DEBUG_BUFFER_SIZE];                                       \
+    snprintf(_buf, DEBUG_BUFFER_SIZE, __VA_ARGS__);                     \
+    DEBUG_SERIAL_PORT.print("[" DEBUG_MODULE "] ");                     \
+    DEBUG_SERIAL_PORT.println(_buf);                                    \
   } while (0);
 
 // Use DEBUG_PRINT_EVERY to add print messages line printf, but it will only
 // print the message every i times the line is reached (note: it costs 2 bytes
 // to remember this per line)
-#define DEBUG_PRINT_EVERY(i, ...)                     \
-  do {                                                \
-    static unsigned int _count = 0;                   \
-    if ((++_count) / i) {                             \
-      DEBUG_PRINT(__VA_ARGS__);                       \
-      _count = 0;                                     \
-    }                                                 \
+#define DEBUG_PRINT_EVERY(i, ...)                                       \
+  do {                                                                  \
+    static unsigned int _count = (i - __LINE__) % i;   \
+    if (i - (++_count) == 0) {                                          \
+      DEBUG_PRINT(__VA_ARGS__);                                         \
+      _count = 0;                                                       \
+    }                                                                   \
   } while (0);
 
 #else

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -34,7 +34,7 @@
 // to remember this per line)
 #define DEBUG_PRINT_EVERY(i, ...)                                       \
   do {                                                                  \
-    static unsigned int _count = (i - __LINE__) % i;   \
+    static unsigned int _count = (i - __LINE__) % i;                    \
     if (i - (++_count) == 0) {                                          \
       DEBUG_PRINT(__VA_ARGS__);                                         \
       _count = 0;                                                       \

--- a/src/util/metrics.cpp
+++ b/src/util/metrics.cpp
@@ -28,11 +28,12 @@ void metricsStop(struct metrics* metrics)
   uint32_t time = ((uint32_t) micros()) - metrics->current;
   metrics->count++;
   
-  // Handle rollover of sum (which should always rollover faster than sum
+  // Handle rollover of sum (which should always rollover faster than counter)
   if (metrics->sum + time < metrics->sum) {
     // TODO: Find a better solution
     //       For now, set sum to a reasonable multiplier of the average so the current
     //       time can continue to be rolled in without dominating the average
+    //       See github PR #34 for a short discussion on possible improvements/modifications
     metrics->count = 100;
     metrics->sum = metrics->average * metrics->count;
   }

--- a/src/util/metrics.cpp
+++ b/src/util/metrics.cpp
@@ -10,6 +10,7 @@
 void metricsReset(struct metrics* metrics)
 {
   metrics->count = 0;
+  metrics->sum = 0;
   metrics->average = 0;
   metrics->maximum = 0;
   metrics->minimum = UINT32_MAX;

--- a/src/util/metrics.cpp
+++ b/src/util/metrics.cpp
@@ -1,0 +1,44 @@
+
+#include <stdint.h>
+
+// TODO: Clean up Arduino code from this file
+#include <Arduino.h>
+
+#include "../util/utils.h"
+#include "../util/metrics.h"
+
+void metricsReset(struct metrics* metrics)
+{
+  metrics->count = 0;
+  metrics->average = 0;
+  metrics->maximum = 0;
+  metrics->minimum = UINT32_MAX;
+  return;
+}
+
+void metricsStart(struct metrics* metrics)
+{
+  metrics->current = (uint32_t) micros();
+  return;
+}
+
+void metricsStop(struct metrics* metrics)
+{
+  uint32_t time = ((uint32_t) micros()) - metrics->current;
+  metrics->count++;
+  
+  // Handle rollover of sum (which should always rollover faster than sum
+  if (metrics->sum + time < metrics->sum) {
+    // TODO: Find a better solution
+    //       For now, set sum to a reasonable multiplier of the average so the current
+    //       time can continue to be rolled in without dominating the average
+    metrics->count = 100;
+    metrics->sum = metrics->average * metrics->count;
+  }
+  
+  metrics->sum += time;
+  metrics->average = metrics->sum / metrics->count;
+  metrics->minimum = min(time, metrics->minimum);
+  metrics->maximum = max(time, metrics->maximum);
+  return;
+}

--- a/src/util/metrics.h
+++ b/src/util/metrics.h
@@ -1,0 +1,25 @@
+
+#ifndef __METRICS_UTIL_H__
+#define __METRICS_UTIL_H__
+
+#include <stdint.h>
+
+struct metrics {
+  uint32_t count;
+  uint32_t sum;
+  uint32_t current;
+  uint32_t average;
+  uint32_t maximum;
+  uint32_t minimum;
+};
+
+// TODO: Doc
+void metricsReset(struct metrics* metrics);
+
+// TODO: Doc
+void metricsStart(struct metrics* metrics);
+
+// TODO: Doc
+void metricsStop(struct metrics* metrics);
+
+#endif /* __METRICS_UTIL_H__ */

--- a/src/util/utils.h
+++ b/src/util/utils.h
@@ -1,0 +1,16 @@
+
+#ifndef __UTILS_UTIL_H__
+#define __UTILS_UTIL_H__
+
+// Standard math utility macros
+
+// TODO: Consider safer macros here for these operations
+#ifndef max
+#define max(a, b) ((a) < (b) ? (b) : (a))
+#endif
+
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#endif /* __UTILS_UTIL_H__ */


### PR DESCRIPTION
Add metrics infrastructure to help figure out the timing of each thread (and the main loop) to help make sure everything can be invoked quickly enough.