### PR TITLE
serial: fix for case where message length is zero

### DIFF
--- a/src/hal/serial.cpp
+++ b/src/hal/serial.cpp
@@ -219,7 +219,7 @@ int serialHalHandleRx(int (*processPacket)(uint8_t packetType, uint8_t packetLen
     {
       crcCalculated=_crc_xmodem_update(crcCalculated,inByte);
       msgLen=inByte;
-      if (msgLen>SERIAL_MAX_DATA_SIZE)
+      if (msgLen>SERIAL_MAX_DATA_SIZE || msgLen==0)
       {
         rxState=SERIAL_RX_STATE_START1;
         serial_statistics.packetsCntWrongLength++;


### PR DESCRIPTION
In the case where message length is zero, skip over reading out the data field from the packet. In the current design, this should only happen if the packet is corrupted but a zero length package is possible from the specification.